### PR TITLE
 Ajout des fonctionnalités ingress alb

### DIFF
--- a/poc-outpost/addons.tf
+++ b/poc-outpost/addons.tf
@@ -1,0 +1,111 @@
+module "eks_blueprints_addons" {
+  source  = "aws-ia/eks-blueprints-addons/aws"
+  version = "~> 1.2"
+
+  cluster_name      = module.eks.cluster_name
+  cluster_endpoint  = module.eks.cluster_endpoint
+  cluster_version   = module.eks.cluster_version
+  oidc_provider_arn = module.eks.oidc_provider_arn
+
+  #---------------------------------------
+  # AWS Load Balancer Controller Add-on
+  #---------------------------------------
+  enable_aws_load_balancer_controller = true
+  # turn off the mutating webhook for services because we are using
+  # service.beta.kubernetes.io/aws-load-balancer-type: external
+  aws_load_balancer_controller = {
+    set = [{
+      name  = "enableServiceMutatorWebhook"
+      value = "false"
+    }]
+  }
+  tags = local.tags
+}
+
+  #---------------------------------------
+  # Amazon EKS Managed Add-ons
+  #---------------------------------------
+#   eks_addons = {
+#     aws-ebs-csi-driver = {
+#       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
+#     }
+#     coredns    = {}
+#     kube-proxy = {}
+#     # VPC CNI uses worker node IAM role policies
+#     vpc-cni = {}
+#   }
+
+  #---------------------------------------
+  # Metrics Server
+  #---------------------------------------
+#   enable_metrics_server = true
+#   metrics_server = {
+#     timeout = "300"
+#     values  = [templatefile("${path.module}/helm/metrics-server/values.yaml", {})]
+#   }
+
+  #---------------------------------------
+  # Cluster Autoscaler
+  #---------------------------------------
+#   enable_cluster_autoscaler = true
+#   cluster_autoscaler = {
+#     timeout     = "300"
+#     create_role = true
+#     values = [templatefile("${path.module}/helm/cluster-autoscaler/values.yaml", {
+#       aws_region     = var.region,
+#       eks_cluster_id = module.eks.cluster_name
+#     })]
+#   }
+
+  #---------------------------------------
+  # Karpenter Autoscaler for EKS Cluster
+  #---------------------------------------
+#   enable_karpenter                  = true
+#   karpenter_enable_spot_termination = true
+#   karpenter_node = {
+#     iam_role_additional_policies = {
+#       AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+#     }
+#   }
+#   karpenter = {
+#     chart_version       = "0.37.0"
+#     repository_username = data.aws_ecrpublic_authorization_token.token.user_name
+#     repository_password = data.aws_ecrpublic_authorization_token.token.password
+#   }
+
+  #---------------------------------------
+  # Prometheus and Grafana stack
+  #---------------------------------------
+  #---------------------------------------------------------------
+  # Install Monitoring Stack with Prometheus and Grafana
+  # 1- Grafana port-forward `kubectl port-forward svc/kube-prometheus-stack-grafana 8080:80 -n kube-prometheus-stack`
+  # 2- Grafana Admin user: admin
+  # 3- Get admin user password: `aws secretsmanager get-secret-value --secret-id <output.grafana_secret_name> --region $AWS_REGION --query "SecretString" --output text`
+  #---------------------------------------------------------------
+#   enable_kube_prometheus_stack = true
+#   kube_prometheus_stack = {
+#     values        = [templatefile("${path.module}/helm/kube-prometheus-stack/values.yaml", {})]
+#     chart_version = "48.1.1"
+#     set_sensitive = [
+#       {
+#         name  = "grafana.adminPassword"
+#         value = data.aws_secretsmanager_secret_version.admin_password_version.secret_string
+#       }
+#     ],
+#   }
+  #---------------------------------------
+  # AWS for FluentBit
+  #---------------------------------------
+#   enable_aws_for_fluentbit = true
+#   aws_for_fluentbit_cw_log_group = {
+#     use_name_prefix   = false
+#     name              = "/${local.name}/aws-fluentbit-logs" # Add-on creates this log group
+#     retention_in_days = 30
+#   }
+#   aws_for_fluentbit = {
+#     values = [templatefile("${path.module}/helm/aws-for-fluentbit/values.yaml", {
+#       region               = local.region,
+#       cloudwatch_log_group = "/${local.name}/aws-fluentbit-logs"
+#       cluster_name         = module.eks.cluster_name
+#     })]
+#   }

--- a/poc-outpost/install_eks_ca_from_terraform.sh
+++ b/poc-outpost/install_eks_ca_from_terraform.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CERT_BASE64=$(terraform output -raw eks_cluster_certificate_authority_data)
+CERT_FILE="/usr/local/share/ca-certificates/eks-cluster.crt"
+
+echo "🔐 Décodage du certificat depuis Terraform..."
+echo "$CERT_BASE64" | base64 -d | sudo tee "$CERT_FILE" > /dev/null
+
+echo "📥 Mise à jour des autorités de certification..."
+sudo update-ca-certificates
+
+echo "✅ Certificat du cluster EKS installé avec succès."

--- a/poc-outpost/main.tf
+++ b/poc-outpost/main.tf
@@ -1,6 +1,8 @@
-# data "aws_eks_cluster_auth" "this" {
-#   name = local.name
-# }
+# Récupération des informations pour la connexion au cluster EKS
+# Utilise en particulier pour les modules helm et kubectl
+data "aws_eks_cluster_auth" "this" {
+  name = local.name
+}
 # Read AZ for current region
 data "aws_availability_zones" "available" {}
 # Read Outpost informations

--- a/poc-outpost/modules/outpost_subnet/outputs.tf
+++ b/poc-outpost/modules/outpost_subnet/outputs.tf
@@ -1,6 +1,5 @@
 output "subnet_id" {
   description = "The ID of the Outpost private subnet"
-  type        = list(string)
   value = [aws_subnet.outpost_private.id]
 }
 

--- a/poc-outpost/outputs.tf
+++ b/poc-outpost/outputs.tf
@@ -7,3 +7,18 @@
 #   description = "Grafana password secret name"
 #   value       = aws_secretsmanager_secret.grafana.name
 # }
+output "eks_cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+  description = "Le certificat CA utilisé par le serveur API EKS"
+  sensitive = true
+}
+
+output "eks_cluster_endpoint" {
+  value       = module.eks.cluster_endpoint
+  description = "Le endpoint du cluster EKS"
+}
+
+output "eks_cluster_name" {
+  value       = module.eks.cluster_name
+  description = "Nom du cluster EKS"
+}

--- a/poc-outpost/providers.tf
+++ b/poc-outpost/providers.tf
@@ -7,24 +7,26 @@ provider "aws" {
   alias  = "virginia"
 }
 
-# provider "kubernetes" {
-#   host                   = module.eks.cluster_endpoint
-#   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-#   token                  = data.aws_eks_cluster_auth.this.token
-# }
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  #cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+  insecure = true
+}
 
-# provider "helm" {
-#   kubernetes {
-#     host                   = module.eks.cluster_endpoint
-#     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-#     token                  = data.aws_eks_cluster_auth.this.token
-#   }
-# }
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    #cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+    insecure = true
+  }
+}
 
-# provider "kubectl" {
-#   apply_retry_count      = 10
-#   host                   = module.eks.cluster_endpoint
-#   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-#   load_config_file       = false
-#   token                  = data.aws_eks_cluster_auth.this.token
-# }
+provider "kubectl" {
+  apply_retry_count      = 10
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.this.token
+}

--- a/poc-outpost/tests/loadbalancer-test.yaml
+++ b/poc-outpost/tests/loadbalancer-test.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alb-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-world
+  namespace: alb-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      containers:
+      - name: hello
+        image: public.ecr.aws/nginx/nginx:latest
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-service
+  namespace: alb-test
+spec:
+  type: ClusterIP 
+  selector:
+    app: hello
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-ingress
+  namespace: alb-test
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-service
+                port:
+                  number: 80

--- a/poc-outpost/versions.tf
+++ b/poc-outpost/versions.tf
@@ -6,21 +6,21 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.95"  # Certains modules ne fonctionnent pas avec les versions 6.X 
     }
-    # kubernetes = {
-    #   source  = "hashicorp/kubernetes"
-    #   version = ">= 2.10"
-    # }
-    # helm = {
-    #   source  = "hashicorp/helm"
-    #   version = "~> 2.17"
-    # }
-    # kubectl = {
-    #   source  = "alekc/kubectl"
-    #   version = ">= 2.0.2"
-    # }
-    # random = {
-    #   source  = "hashicorp/random"
-    #   version = ">= 3.1"
-    # }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1.0"
+    }
   }
 }

--- a/poc-outpost/vpc.tf
+++ b/poc-outpost/vpc.tf
@@ -23,6 +23,11 @@ module "vpc" {
     "fake" = "true"
   }
 
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1,
+    "kubernetes.io/cluster/${local.name}" = "owned"
+  }
+
   # LIMITATION ACTUELLE DU MODULE VPC.
   # Le module active directement les COIP (Pool IP dans Outpost) si outpost_arn est setté. 
   # Mais l'outpost du POC est "No CoIP pools available with direct VPC routing 


### PR DESCRIPTION
1.     Déploiement de aws-load-balancer-controller dans le kube-system du cluster. (fichier addons)
2. Tag sur les subnets publique pour que le load balancer controller sache sur quel subnet créé le loadbalancer
3. Création d'un sample de test de déploiement d'un nginx pour vérifier la bonne création du LB dans AWS et la bonne connectité (ok sur http://k8s-albtest-helloing-8d858ea969-1936010195.us-west-2.elb.amazonaws.com/)
4. Script utilitaire pour l'ajout du certificat EKS dans un trust store local (test sur ubuntu)